### PR TITLE
ci: include hidden files in GitHub Pages artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,9 +45,10 @@ jobs:
         run: bundle exec jekyll build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v4.0.1
         with:
           path: ./_site
+          include-hidden-files: true
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the GitHub Pages artifact upload action to a version that supports hidden-file inclusion
- enable `include-hidden-files: true` so `.well-known/*` is preserved in the uploaded Pages artifact

## Why
`_config.yml` already includes `.well-known`, but `actions/upload-pages-artifact@v4.0.0` excluded dot-prefixed paths from the deploy artifact. As a result, `/.well-known/atproto-did` was missing in production despite existing in the repo.

## Validation
- confirmed `.well-known/atproto-did` exists in source and on upstream `main`
- confirmed current public URL returned 404 before this workflow fix
- verified deploy workflow now uploads hidden files by configuration
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7962d22b-f975-4591-b3fa-17bb9fd594f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7962d22b-f975-4591-b3fa-17bb9fd594f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

